### PR TITLE
windows: shorten conan cache path

### DIFF
--- a/.github/workflows/proof-of-conan.yml
+++ b/.github/workflows/proof-of-conan.yml
@@ -20,6 +20,12 @@ jobs:
   checkout:
     runs-on: ubuntu-latest
     steps:
+      - run: |
+          echo "Building Conan Package" >> $GITHUB_STEP_SUMMARY
+          echo "- repo: ${{ github.event.inputs.repository }}" >> $GITHUB_STEP_SUMMARY
+          echo "- gitref: ${{ github.event.inputs.ref }}" >> $GITHUB_STEP_SUMMARY
+          echo "- path: ${{ github.event.inputs.path }}" >> $GITHUB_STEP_SUMMARY
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -70,6 +76,11 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'proof-of-conan/requirements.txt'
       - run: pip3 install -r proof-of-conan/requirements.txt
+
+      - name: set conan home
+        if: ${{ runner.os == 'Windows' }}
+        shell: bash
+        run: echo "CONAN_HOME=${{ runner.temp }}\\.c2" >> $GITHUB_ENV
 
       - run: conan profile detect --force
         shell: bash

--- a/src/targets.ts
+++ b/src/targets.ts
@@ -21,7 +21,7 @@ export default [
     enabled: true,
   },
   {
-    os: "macos-latest",
+    os: "macos-11",
     cmd: "--build=outdated",
     enabled: true,
   },

--- a/src/targets.ts
+++ b/src/targets.ts
@@ -1,38 +1,38 @@
 export default [
   {
     os: "ubuntu-latest",
-    cmd: "--build=outdated",
+    cmd: "--build=missing",
     enabled: true,
   },
   {
     os: "windows-latest",
-    cmd: "--build=outdated",
+    cmd: "--build=missing",
     enabled: true,
   },
   {
     os: "windows-latest",
     toolchain: "mingw-builds/11.2.0",
-    cmd: "--build=outdated",
+    cmd: "--build=missing",
     enabled: true,
   },
   {
     os: "ubuntu-latest",
-    cmd: "--build=outdated -s compiler.libcxx=libstdc++11",
+    cmd: "--build=missing -s compiler.libcxx=libstdc++11",
     enabled: true,
   },
   {
     os: "macos-11",
-    cmd: "--build=outdated",
+    cmd: "--build=missing",
     enabled: true,
   },
   {
     os: "ubuntu-latest",
     container: "conanio/gcc9-armv7hf",
-    cmd: "--build=outdated -s:h arch=armv7hf",
+    cmd: "--build=missing -s:h arch=armv7hf",
   },
   {
     os: "ubuntu-latest",
     container: "conanio/gcc9",
-    cmd: "--build=outdated",
+    cmd: "--build=missing",
   },
 ];


### PR DESCRIPTION
also:
- add a job summary to find out what is build built
- downgrade to macos-11, because conan-center has no binaries available for macos-latest
- use build=missing, because build=outdated does not exist in conan 2