### PR TITLE
restrict token permissions

### DIFF
--- a/.github/workflows/proof-of-conan.yml
+++ b/.github/workflows/proof-of-conan.yml
@@ -16,6 +16,9 @@ on:
         required: true
         description: 'JSON of all your targets'
 
+permissions:
+  contents: read
+
 jobs:
   checkout:
     runs-on: ubuntu-latest


### PR DESCRIPTION
artifact upload should continue to work, according to https://github.com/actions/upload-artifact/issues/197#issuecomment-832279436