### PR TITLE
allow stars in conan command

### DIFF
--- a/.github/workflows/proof-of-conan.yml
+++ b/.github/workflows/proof-of-conan.yml
@@ -51,17 +51,6 @@ jobs:
       CONAN_CMD: ${{ matrix.conancmd }}
       CONTAINER: ${{ matrix.container }}
     steps:
-      # Yes I understand this check doesn't mean much when I'm anyway going
-      # to run random python-scripts, but at least those need an account.
-      - run: |
-          # https://unix.stackexchange.com/a/498744
-          case "$CONAN_CMD" in
-            ("" | *[!abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890./@\-\ =+\'_:*]*)
-              echo "NOT ALLOWED" && exit 1;;
-            (*)
-              echo "test=$CONAN_CMD" >> $GITHUB_OUTPUT;;
-          esac
-        shell: bash
       - uses: actions/download-artifact@v3
         with:
           name: repo

--- a/.github/workflows/proof-of-conan.yml
+++ b/.github/workflows/proof-of-conan.yml
@@ -56,7 +56,7 @@ jobs:
       - run: |
           # https://unix.stackexchange.com/a/498744
           case "$CONAN_CMD" in
-            ("" | *[!abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890./@\-\ =+\'_:]*)
+            ("" | *[!abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890./@\-\ =+\'_:*]*)
               echo "NOT ALLOWED" && exit 1;;
             (*)
               echo "test=$CONAN_CMD" >> $GITHUB_OUTPUT;;


### PR DESCRIPTION
this allows replicating Conan-Center configuration `-o */*:shared=True`

This change probably annihilates the benefit of this regex though. I don't know which malicious command could be caught by this new regex.
One could argue that the regex could be already considered redundant, now that `matrix.conancmd` is never used directly, but only as expansion of environment variable `CONAN_CMD`. Also, there may be nothing left needed to be protected, now that the token permissions are reduced to the minimum set (contents:read)